### PR TITLE
Add support for authenticating requests using tokens in the Authorization header

### DIFF
--- a/middleware.go
+++ b/middleware.go
@@ -87,6 +87,7 @@ func (t *TraefikOidc) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 		if err := t.verifyToken(token); err != nil {
 			t.sendErrorResponse(rw, req, "Unauthorized", http.StatusUnauthorized)
 		}
+		t.next.ServeHTTP(rw, req)
 		return
 	}
 

--- a/middleware.go
+++ b/middleware.go
@@ -87,6 +87,7 @@ func (t *TraefikOidc) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 		if err := t.verifyToken(token); err != nil {
 			t.sendErrorResponse(rw, req, "Unauthorized", http.StatusUnauthorized)
 		}
+		req.Header.Del("Authorization")
 		t.next.ServeHTTP(rw, req)
 		return
 	}

--- a/session.go
+++ b/session.go
@@ -974,7 +974,7 @@ func (sm *SessionManager) CreateSessionFromAccessToken(accessToken string) (*Ses
 	}
 
 	email := resolveClaim("email", "upn", "preferred_username")
-	if email == "" || !strings.Contains(email, "@") {
+	if email == "" {
 		if sm.logger != nil {
 			sm.logger.Debug("CreateSessionFromAccessToken: missing email-like claim")
 		}

--- a/session.go
+++ b/session.go
@@ -859,6 +859,178 @@ func (sm *SessionManager) GetSession(r *http.Request) (*SessionData, error) {
 	return sessionData, nil
 }
 
+// CreateSessionFromAccessToken builds an in-memory session using only a validated access token.
+// It constructs synthetic session state so downstream components that expect session-backed
+// data (like headers or domain checks) can operate without cookie persistence.
+// Parameters:
+//   - accessToken: The validated access token presented via an Authorization header.
+//
+// Returns:
+//   - A populated *SessionData instance representing the token-authenticated user.
+//   - An error if the token is empty, malformed, or missing essential claims.
+func (sm *SessionManager) CreateSessionFromAccessToken(accessToken string) (*SessionData, error) {
+	trimmedToken := strings.TrimSpace(accessToken)
+	if trimmedToken == "" {
+		return nil, fmt.Errorf("access token cannot be empty")
+	}
+
+	if len(trimmedToken) > AccessTokenConfig.MaxLength {
+		return nil, fmt.Errorf("access token exceeds maximum length of %d bytes", AccessTokenConfig.MaxLength)
+	}
+
+	if strings.Count(trimmedToken, ".") != 2 {
+		return nil, fmt.Errorf("access token must be a JWT with three segments")
+	}
+
+	sessionInterface := sm.sessionPool.Get()
+	sessionData, _ := sessionInterface.(*SessionData)
+	if sessionData == nil {
+		sessionData = &SessionData{
+			manager:            sm,
+			accessTokenChunks:  make(map[int]*sessions.Session),
+			refreshTokenChunks: make(map[int]*sessions.Session),
+			idTokenChunks:      make(map[int]*sessions.Session),
+		}
+	}
+
+	atomic.AddInt64(&sm.poolHits, 1)
+	atomic.AddInt64(&sm.activeSessions, 1)
+
+	// Ensure the session starts from a clean slate.
+	sessionData.Reset()
+
+	cleanupOnError := func(err error) (*SessionData, error) {
+		if sessionData != nil {
+			sessionData.Reset()
+			sm.sessionPool.Put(sessionData)
+			atomic.AddInt64(&sm.activeSessions, -1)
+		}
+		return nil, err
+	}
+
+	// Initialize session containers for synthetic usage.
+	ensureSession := func(target **sessions.Session, name string) {
+		if *target == nil {
+			*target = sessions.NewSession(sm.store, name)
+		} else {
+			clearSessionValues(*target, false)
+			(*target).ID = ""
+			(*target).IsNew = true
+		}
+		if (*target).Values == nil {
+			(*target).Values = make(map[interface{}]interface{})
+		}
+	}
+
+	ensureSession(&sessionData.mainSession, mainCookieName)
+	ensureSession(&sessionData.accessSession, accessTokenCookie)
+	ensureSession(&sessionData.refreshSession, refreshTokenCookie)
+	ensureSession(&sessionData.idTokenSession, idTokenCookie)
+
+	if sessionData.accessTokenChunks == nil {
+		sessionData.accessTokenChunks = make(map[int]*sessions.Session)
+	} else {
+		for k := range sessionData.accessTokenChunks {
+			delete(sessionData.accessTokenChunks, k)
+		}
+	}
+
+	if sessionData.refreshTokenChunks == nil {
+		sessionData.refreshTokenChunks = make(map[int]*sessions.Session)
+	} else {
+		for k := range sessionData.refreshTokenChunks {
+			delete(sessionData.refreshTokenChunks, k)
+		}
+	}
+
+	if sessionData.idTokenChunks == nil {
+		sessionData.idTokenChunks = make(map[int]*sessions.Session)
+	} else {
+		for k := range sessionData.idTokenChunks {
+			delete(sessionData.idTokenChunks, k)
+		}
+	}
+
+	claims, err := extractClaims(trimmedToken)
+	if err != nil {
+		if sm.logger != nil {
+			sm.logger.Debugf("CreateSessionFromAccessToken: failed to extract claims: %v", err)
+		}
+		return cleanupOnError(fmt.Errorf("failed to parse access token claims: %w", err))
+	}
+
+	resolveClaim := func(keys ...string) string {
+		for _, key := range keys {
+			if raw, exists := claims[key]; exists {
+				if value, ok := raw.(string); ok {
+					value = strings.TrimSpace(value)
+					if value != "" {
+						return value
+					}
+				}
+			}
+		}
+		return ""
+	}
+
+	email := resolveClaim("email", "upn", "preferred_username")
+	if email == "" || !strings.Contains(email, "@") {
+		if sm.logger != nil {
+			sm.logger.Debug("CreateSessionFromAccessToken: missing email-like claim")
+		}
+		return cleanupOnError(fmt.Errorf("access token missing required email claim"))
+	}
+
+	subject := resolveClaim("sub")
+
+	sessionData.sessionMutex.Lock()
+	defer sessionData.sessionMutex.Unlock()
+
+	// Synthesize authenticated session state without marking it dirty for persistence.
+	sessionData.mainSession.Values["authenticated"] = true
+	sessionData.mainSession.Values["created_at"] = time.Now().Unix()
+	sessionData.mainSession.Values["email"] = email
+	sessionData.mainSession.Values["redirect_count"] = 0
+	if subject != "" {
+		sessionData.mainSession.Values["subject"] = subject
+	}
+	sessionData.mainSession.IsNew = false
+
+	storedToken := trimmedToken
+	isCompressed := false
+	compressed := compressToken(trimmedToken)
+	if compressed != trimmedToken {
+		if decompressed := decompressToken(compressed); decompressed == trimmedToken {
+			storedToken = compressed
+			isCompressed = true
+		}
+	}
+
+	sessionData.accessSession.Values["token"] = storedToken
+	sessionData.accessSession.Values["compressed"] = isCompressed
+	sessionData.accessSession.IsNew = false
+
+	sessionData.refreshSession.Values["token"] = ""
+	sessionData.refreshSession.Values["compressed"] = false
+	sessionData.refreshSession.IsNew = false
+
+	sessionData.idTokenSession.Values["token"] = ""
+	sessionData.idTokenSession.Values["compressed"] = false
+	sessionData.idTokenSession.IsNew = false
+
+	if sessionID, genErr := generateSecureRandomString(64); genErr == nil {
+		sessionData.mainSession.ID = sessionID
+	} else if sm.logger != nil {
+		sm.logger.Debugf("CreateSessionFromAccessToken: failed to generate session id: %v", genErr)
+	}
+
+	sessionData.request = nil
+	sessionData.dirty = false
+	sessionData.inUse = true
+
+	return sessionData, nil
+}
+
 // getTokenChunkSessions loads all available token chunk sessions for a given token type.
 // It iterates through numbered chunk sessions until no more are found,
 // populating the provided chunks map with the loaded sessions.

--- a/session_test.go
+++ b/session_test.go
@@ -206,6 +206,81 @@ func TestSessionErrorHandling(t *testing.T) {
 	_ = runner
 }
 
+func TestCreateSessionFromAccessToken(t *testing.T) {
+	logger := NewLogger("error")
+	sm, err := NewSessionManager("0123456789abcdef0123456789abcdef0123456789abcdef", false, "", logger)
+	if err != nil {
+		t.Fatalf("Failed to create session manager: %v", err)
+	}
+	defer func() {
+		if shutdownErr := sm.Shutdown(); shutdownErr != nil {
+			t.Logf("Session manager shutdown error: %v", shutdownErr)
+		}
+	}()
+
+	tokens := NewTestTokens()
+	session, err := sm.CreateSessionFromAccessToken(tokens.CreateValidJWT())
+	if err != nil {
+		t.Fatalf("CreateSessionFromAccessToken failed: %v", err)
+	}
+	defer session.returnToPoolSafely()
+
+	if !session.GetAuthenticated() {
+		t.Fatalf("Expected session to be authenticated")
+	}
+
+	if email := session.GetEmail(); email != "test@example.com" {
+		t.Fatalf("Unexpected email stored in session: %s", email)
+	}
+
+	if token := session.GetAccessToken(); token != tokens.CreateValidJWT() {
+		t.Fatalf("Access token mismatch, expected %s got %s", tokens.CreateValidJWT(), token)
+	}
+
+	if session.IsDirty() {
+		t.Fatalf("Synthetic session should not be marked dirty")
+	}
+}
+
+func TestCreateSessionFromAccessTokenMissingEmail(t *testing.T) {
+	logger := NewLogger("error")
+	sm, err := NewSessionManager("fedcba9876543210fedcba9876543210fedcba9876543210", false, "", logger)
+	if err != nil {
+		t.Fatalf("Failed to create session manager: %v", err)
+	}
+	defer func() {
+		if shutdownErr := sm.Shutdown(); shutdownErr != nil {
+			t.Logf("Session manager shutdown error: %v", shutdownErr)
+		}
+	}()
+
+	header := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"RS256","kid":"test"}`))
+	claims := map[string]interface{}{
+		"iss": "https://issuer.example.com",
+		"aud": "test-client",
+		"exp": time.Now().Add(time.Hour).Unix(),
+		"sub": "user-123",
+	}
+	claimsBytes, marshalErr := json.Marshal(claims)
+	if marshalErr != nil {
+		t.Fatalf("Failed to marshal claims: %v", marshalErr)
+	}
+	payload := base64.RawURLEncoding.EncodeToString(claimsBytes)
+	signature := base64.RawURLEncoding.EncodeToString([]byte("signature"))
+	token := fmt.Sprintf("%s.%s.%s", header, payload, signature)
+
+	session, err := sm.CreateSessionFromAccessToken(token)
+	if session != nil {
+		session.returnToPoolSafely()
+	}
+	if err == nil {
+		t.Fatalf("Expected error for token missing email claim")
+	}
+	if !strings.Contains(err.Error(), "email") {
+		t.Fatalf("Expected error about email claim, got: %v", err)
+	}
+}
+
 // TestSessionClearAlwaysReturnsToPool tests that sessions are always returned to pool even on errors
 func TestSessionClearAlwaysReturnsToPool(t *testing.T) {
 	config := GetTestConfig()


### PR DESCRIPTION
This pull request introduces support for authenticating requests using bearer tokens in the `Authorization` header, allowing for stateless session synthesis without relying on cookies. It adds a new method to create in-memory session data from validated access tokens and includes comprehensive unit tests to verify correct behavior and error handling. The changes improve flexibility and security for downstream components that expect session-backed data.

**Bearer token authentication and session synthesis:**

* Added logic to `ServeHTTP` in `middleware.go` to detect bearer tokens in the `Authorization` header, verify them, and synthesize a session for downstream processing. If the token is invalid or missing, an error response is sent. (`[middleware.goR83-R111](diffhunk://#diff-02f50901140d6057da6310a106670552aa766a093efbc2200fb34c099b762131R83-R111)`)
* Implemented `CreateSessionFromAccessToken` in `session.go`, which constructs a synthetic, in-memory `SessionData` object from a validated JWT access token. This method parses claims, ensures essential fields (like email) are present, and initializes session state without cookie persistence. (`[session.goR862-R1033](diffhunk://#diff-3d4a6b7d54b5107bc5694b7a06383f9ec4c68f9abe43ba0942f5d970f3a8ccacR862-R1033)`)

**Testing and validation:**

* Added unit tests in `session_test.go` to verify session creation from valid access tokens, including checks for authentication, email extraction, token storage, and session cleanliness. (`[session_test.goR209-R283](diffhunk://#diff-f27c62978dcbd8717b591269e831e3cc0eec4fbdb8fbf53f66435cd8450c4557R209-R283)`)
* Added tests to ensure proper error handling when the access token is missing required claims, such as email, confirming robust validation and error reporting. (`[session_test.goR209-R283](diffhunk://#diff-f27c62978dcbd8717b591269e831e3cc0eec4fbdb8fbf53f66435cd8450c4557R209-R283)`)