### PR TITLE
docs: pin documented plugin version to v1.0.29

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ experimental:
   plugins:
     traefikoidc:
       moduleName: github.com/lukaszraczylo/traefikoidc
-      version: v0.7.10
+      version: v1.0.29
 ```
 
 Then attach the middleware in your dynamic configuration (see

--- a/examples/complete-traefik-config.yaml
+++ b/examples/complete-traefik-config.yaml
@@ -51,7 +51,7 @@ experimental:
   plugins:
     traefikoidc:
       moduleName: github.com/lukaszraczylo/traefikoidc
-      version: v0.8.0
+      version: v1.0.29
 
 log:
   level: INFO
@@ -263,7 +263,7 @@ services:
       - "--entrypoints.web.address=:80"
       - "--entrypoints.websecure.address=:443"
       - "--experimental.plugins.traefikoidc.modulename=github.com/lukaszraczylo/traefikoidc"
-      - "--experimental.plugins.traefikoidc.version=v0.8.0"
+      - "--experimental.plugins.traefikoidc.version=v1.0.29"
     ports:
       - "80:80"
       - "443:443"

--- a/examples/redis-config.yaml
+++ b/examples/redis-config.yaml
@@ -6,7 +6,7 @@ experimental:
   plugins:
     traefikoidc:
       moduleName: github.com/lukaszraczylo/traefikoidc
-      version: v0.8.0
+      version: v1.0.29
 
 # Dynamic configuration (dynamic.yml or labels)
 http:


### PR DESCRIPTION
## Summary

The install snippet in the README pinned `v0.7.10` and both example configs
pinned `v0.8.0`, so anyone following the docs installed a release well behind
the current `v1.0.29`.

If one just uses the example without noticing that there is a considerable version 
drift between the docs and the latest release, this can result in a debugging 
session which could have been avoided. 

## Changes

- `README.md` — static-config install snippet: `v0.7.10` → `v1.0.29`
- `examples/complete-traefik-config.yaml` — file-provider snippet and the
  `--experimental.plugins.traefikoidc.version` CLI flag: `v0.8.0` → `v1.0.29`
- `examples/redis-config.yaml` — static-config snippet: `v0.8.0` → `v1.0.29`

Documentation only — no Go sources, no behaviour change.